### PR TITLE
implement spotify api playlist info endpoint

### DIFF
--- a/server/routes/api/index.js
+++ b/server/routes/api/index.js
@@ -10,6 +10,8 @@ router.post("/search_artists", require("./spotify").search_artists);
 router.post("/me", require("./spotify").me);
 router.post("/me/playlists", require("./spotify").my_playlists);
 
+router.post("/get_playlist", require("./spotify").get_playlist);
+
 router.use((req, res, next) => {
   const error = new Error("Not Found");
   error.status = 404;

--- a/server/routes/api/spotify.js
+++ b/server/routes/api/spotify.js
@@ -92,7 +92,27 @@ const my_playlists = async (req, res) => {
   }
 };
 
+const get_playlist = (req, res) => {
+  const authHeader = req.headers["authorization"];
+  const token = authHeader && authHeader.split(" ")[1];
+  const { query } = req.body;
+
+  spotifyApi.setAccessToken(token);
+
+  spotifyApi.getPlaylist(query).then(
+    (data) => {
+      res.status(200).send(data.body);
+      console.log("Playlist Info:", data.body);
+    },
+    (err) => {
+      console.error(err);
+      res.status(400).send(err);
+    }
+  );
+};
+
 exports.me = me;
 exports.my_playlists = my_playlists;
+exports.get_playlist = get_playlist;
 exports.search_artists = search_artists;
 exports.fetch_spotify_token = fetch_spotify_token;


### PR DESCRIPTION
Implemented api endpoint to get playlist info  `/get_playlist`.  This POST requests will need the header property:  `Authorization` with the value `Bearer <token>`.  The request body should have the following json content: 
```
{
    "query": "playlistId"
}
```